### PR TITLE
Added a whitespace between the title and icons in the Topics page

### DIFF
--- a/topics/index.html
+++ b/topics/index.html
@@ -31,19 +31,19 @@
           >Easter Quiz <i class="fas fa-egg" aria-hidden="true"></i
         ></a>
         <a href="/christmas" id="christmas-btn" class="btn"
-          >Christmas Quiz<i class="fas fa-gift"></i
+          >Christmas Quiz <i class="fas fa-gift"></i
         ></a>
         <a href="/browsers" id="browsers-btn" class="btn">Browsers Quiz</a>
         <a href="/disney" id="disney-btn" class="btn">Disney Quiz</a>
         <a href="/fruit" id="fruit-btn" class="btn"
-          >Fruit Quiz<i class="fas fa-apple-alt"></i
+          >Fruit Quiz <i class="fas fa-apple-alt"></i
         ></a>
         <a href="/football" id="football-btn" class="btn"
-          >Football Quiz<i class="fas fa-futbol"></i
+          >Football Quiz <i class="fas fa-futbol"></i
         ></a>
         <a href="/countries" id="country-btn" class="btn">Country Quiz</a>
         <a href="/presidents" id="presidents-btn" class="btn"
-          >U.S Presidents Quiz<i class="fas fa-flag-usa"></i
+          >U.S Presidents Quiz <i class="fas fa-flag-usa"></i
         ></a>
         <a href="/How-Well-Do-You-Know-Kendall" id="hwdyk-btn" class="btn"
           >How Well Do You Know Kendall Quiz<i class="fas fa-question"></i


### PR DESCRIPTION
# Related Issue/Addition to code

- fixes #14 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Proposed Changes

- Added whitespace between the "Christmas Quiz" title and icon
- Added whitespace between the "Fruit Quiz" title and icon
- Added whitespace between the "Football Quiz" title and icon
- Added whitespace between the "U.S Presidents "Quiz" title and icon


## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

# Screenshots

|         Original         |         Updated          |
| :-------------------: | :--------------------: |
|      ![BEFORE](https://user-images.githubusercontent.com/47388467/183925277-1782aa2c-c439-4305-8132-bb9c10e70776.png)|     ![AFTER](https://user-images.githubusercontent.com/47388467/183925335-c5f9bea8-652d-40d6-ac0c-52c007a8ed50.png)|




